### PR TITLE
add the ability for parameters to have aliases

### DIFF
--- a/docs/gen_paramters_doc.py
+++ b/docs/gen_paramters_doc.py
@@ -111,6 +111,8 @@ for param in params:
     data_label = "Data Type"
     quality_label = "{}_FLAG_W Definitions".format(param['whp_name'])
 
+    aliases = param.get("aliases")
+
     try:
         alternate_units = ",".join(param["alt_units"])
     except KeyError:
@@ -135,6 +137,8 @@ for param in params:
         output += quality_label.ljust(first_col) + ' ' + quality_flags + '\n'
     if "alt_units" in param:
         output += "Alternate Units".ljust(first_col) + ' ' + alternate_units + '\n'
+    if aliases:
+        output += "Aliases".ljust(first_col) + ' ' + ", ".join(aliases) + '\n'
     output += "=" * first_col + ' ' + "=" * second_col + '\n'
 
     output += """

--- a/meta/parameters.schema.json
+++ b/meta/parameters.schema.json
@@ -44,6 +44,14 @@
       },
       "warning": {
         "type": ["string", "null"]
+      },
+      "aliases": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "uniqueItems": true,
+        "minItems": 1
       }
     },
     "required": [


### PR DESCRIPTION
This will print all the "alias" parameters in the documentation.
## Rationale:

We are gearing up for a big "parameter name realignment", basically making them follow some set of rules. This will involve changing the names of some of the parameters to match the new rules. Some mechanism is needed to recognize the old names when working with files that have not been updated yet.
