### PR TITLE
Make error column labels be part of the parameter they are for

### DIFF
--- a/docs/gen_paramters_doc.py
+++ b/docs/gen_paramters_doc.py
@@ -66,6 +66,8 @@ for param in params:
     units_label = "Units"
     data_label = "Data Type"
     quality_label = "{}_FLAG_W Definitions".format(param['whp_name'])
+    error_label = "Error Column Label"
+    error = param.get("error_name", "")
 
     try:
         alternate_units = ",".join(param["alt_units"])
@@ -79,8 +81,8 @@ for param in params:
     if quality_flags == "woce_bottle":
         quality_flags = ":ref:`Bottle Quality Codes`"
 
-    first_col = max(len(units_label), len(data_label), len(quality_label))
-    second_col = max(len(unit), len(data_type), len(quality_flags), len(alternate_units))
+    first_col = max(len(units_label), len(data_label), len(quality_label), len(error_label))
+    second_col = max(len(unit), len(data_type), len(quality_flags), len(alternate_units), len(error))
 
 
 
@@ -91,6 +93,9 @@ for param in params:
         output += quality_label.ljust(first_col) + ' ' + quality_flags + '\n'
     if "alt_units" in param:
         output += "Alternate Units".ljust(first_col) + ' ' + alternate_units + '\n'
+    if "error_name" in param:
+        output += error_label.ljust(first_col) + ' ' + error + '\n'
+
     output += "=" * first_col + ' ' + "=" * second_col + '\n'
 
     output += """

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -33,6 +33,11 @@ Provided with each parameter is a set of information in a table, the information
     Specifies which set of quality flag definitions should be used to interpret a quality flag column for this parameter (if present).
     Current quality flags are: :ref:`bottle <Bottle Quality Codes>`, :ref:`water <Water Quality Codes>`, :ref:`ctd <CTD Quality Codes>`.
     See the :ref:`Quality Codes` section for more information
+* Alternate Units:
+    Some parameters might have alternate units which might also be in data files.
+* Error Column Label:
+    A parameter might contain an error or uncertanty value associated with it.
+    The column which contains the error/uncertanty values for this parameter will have the name listed in this field.
 
 
 Unlisted Parameters

--- a/meta/parameters.json
+++ b/meta/parameters.json
@@ -481,15 +481,8 @@
     "numeric_min": -5.0, 
     "numeric_precision": 2, 
     "whp_name": "DELC13", 
-    "whp_unit": "/MILLE"
-  }, 
-  {
-    "data_type": "decimal", 
-    "field_width": 8, 
-    "flag_w": null, 
-    "numeric_precision": 1, 
-    "whp_name": "C13ERR", 
-    "whp_unit": "/MILLE"
+    "whp_unit": "/MILLE",
+    "error_name": "C13ERR"
   }, 
   {
     "data_type": "decimal", 
@@ -499,15 +492,8 @@
     "numeric_min": -300.0, 
     "numeric_precision": 1, 
     "whp_name": "DELC14", 
-    "whp_unit": "/MILLE"
-  }, 
-  {
-    "data_type": "decimal", 
-    "field_width": 8, 
-    "flag_w": null, 
-    "numeric_precision": 1, 
-    "whp_name": "C14ERR", 
-    "whp_unit": "/MILLE"
+    "whp_unit": "/MILLE",
+    "error_name": "C14ERR"
   }, 
   {
     "data_type": "decimal", 

--- a/meta/parameters.schema.json
+++ b/meta/parameters.schema.json
@@ -12,6 +12,9 @@
         "type": ["string", "null"],
         "minLength": 1
       },
+      "error_name":{
+        "type": ["string"]
+      },
       "flag_w": {
         "enum": ["woce_bottle", "woce_ctd", "woce_discrete", null]
       },


### PR DESCRIPTION
This change removes the two existing "Error" parameter names and make them exist in the parameter object they are associated with.

There is no support for "percentage" type errors, error columns must have the same units as the parameters they are for.

Closes #22 